### PR TITLE
Frontend/Adding line-clamp property to card stack

### DIFF
--- a/frontend/app/components/ui/card-stack.tsx
+++ b/frontend/app/components/ui/card-stack.tsx
@@ -40,12 +40,12 @@ export const CardStack = ({
   };
 
   return (
-    <div className="relative  h-60 w-60 md:h-60 md:w-96">
+    <div className="relative h-60 w-60 md:h-60 md:w-96">
       {cards.map((card, index) => {
         return (
           <motion.div
             key={card.id}
-            className="absolute flex h-60 w-60 flex-col justify-between rounded-3xl border border-neutral-200 bg-white p-4 shadow-xl shadow-black/[0.1]  dark:border-white/[0.1] dark:bg-black dark:shadow-white/[0.05] md:h-60 md:w-96"
+            className="absolute flex h-60 w-60 flex-col justify-between rounded-3xl border border-neutral-200 bg-white p-4 shadow-xl shadow-black/[0.1] dark:border-white/[0.1] dark:bg-black dark:shadow-white/[0.05] md:h-60 md:w-96"
             style={{
               transformOrigin: 'top center'
             }}
@@ -55,7 +55,7 @@ export const CardStack = ({
               zIndex: cards.length - index //  decrease z-index for the cards that are behind
             }}
           >
-            <div className="font-normal text-neutral-700 dark:text-neutral-200">
+            <div className="font-normal text-neutral-700 dark:text-neutral-200 line-clamp-6 overflow-hidden">
               {card.content}
             </div>
             <div>


### PR DESCRIPTION
Adds line-clamp CSS property to avoid overflow in `ReviewStack`

## Before
![image](https://github.com/WongDarren/zoomers/assets/82336989/63d68d4f-1734-4c81-ac3e-2f8bdb197386)


## After
![image](https://github.com/WongDarren/zoomers/assets/82336989/7ca7e2b1-28c4-4eb7-9f89-8cd17d6914b9)
