### PR TITLE
Backend/add route protection to authenticated routes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,6 @@
 
 ## Misc
 
-- [] Determine which user is logged in after auth. We should consider not using OAuth for now so that we have more control over user auth
+- [ ] Determine which user is logged in after auth. We should consider not using OAuth for now so that we have more control over user auth
 - [ ] Integrate ESLint into project for better standardization.
 - [ ] Create TS Docs and Python Docstrings for all functions

--- a/TODO.md
+++ b/TODO.md
@@ -19,11 +19,11 @@
   - [ ] Get all reviews of followed users
   - [ ] Get all of own reviews
   - [x] Get all reviews of specific movie/tv show
-  - [ ] Create backend route to get the average rating for a movie/tv show
-  - [ ] Create validation function that accepts JWT and validates users
+  - [x] Create backend route to get the average rating for a movie/tv show
+  - [x] Create validation function that accepts JWT and validates users
 
 ## Misc
 
-- [ ] Determine which user is logged in after auth. We should consider not using OAuth for now so that we have more control over user auth
+- [] Determine which user is logged in after auth. We should consider not using OAuth for now so that we have more control over user auth
 - [ ] Integrate ESLint into project for better standardization.
 - [ ] Create TS Docs and Python Docstrings for all functions

--- a/backend/db/schemas.py
+++ b/backend/db/schemas.py
@@ -75,5 +75,4 @@ class UserCreate(BaseModel):
 
 
 class FollowCreate(BaseModel):
-    followerId: int
-    followedId: int
+    idToFollow: int

--- a/backend/db/schemas.py
+++ b/backend/db/schemas.py
@@ -32,7 +32,6 @@ class ReviewSchema(BaseModel):
 
 
 class ReviewCreate(BaseModel):
-    User: int
     stars: float
     ReviewText: str
     MediaId: int

--- a/backend/main.py
+++ b/backend/main.py
@@ -413,8 +413,6 @@ def get_my_reviews(
     return reviews
 
 
-# TODO: We might need to start only allowing these requests to go through
-#  if the JWT is valid and the user is authenticated.
 @app.post("/follow/", status_code=status.HTTP_201_CREATED)
 def create_follow(
     follow: FollowCreate,
@@ -425,16 +423,17 @@ def create_follow(
     Create a new follow relationship between two users.
 
     Args:
-        follow (FollowCreate): The follow relationship to be created.
-        db (Session, optional): The database session. Defaults to Depends(get_db).
+        follow (FollowCreate): The follow object containing the ID of the user to follow.
+        payload (dict): The payload extracted from the JWT token.
+        db (Session): The database session.
 
     Returns:
-        dict: A dictionary containing a success message.
+        dict: A json object with a success message if the follow operation is successful.
 
     Raises:
-        HTTPException: If the follow relationship already exists or if there is an internal server error.
+        HTTPException: If the user ID is not found or if the user is already being followed.
+        HTTPException: If there is an internal server error during the database operation.
     """
-
     user_id = payload.get("user_id")
     if not user_id:
         raise HTTPException(
@@ -469,27 +468,31 @@ def create_follow(
     return {"message": "Follow successful"}
 
 
-# TODO: We might need to start only allowing these requests to go through
-#  if the JWT is valid and the user is authenticated.
 @app.delete("/unfollow/", status_code=status.HTTP_200_OK)
-def unfollow_user(followerId: int, followedId: int, db: Session = Depends(get_db)):
+def unfollow_user(
+    followedId: int,
+    payload: dict = Depends(validate_jwt),
+    db: Session = Depends(get_db),
+):
     """
     Unfollows a user by deleting the follow relationship from the database.
 
     Args:
-        followerId (int): The ID of the follower user.
-        followedId (int): The ID of the user being followed.
-        db (Session, optional): The database session. Defaults to Depends(get_db).
-
+        followedId (int): The ID of the user to unfollow.
+        payload (dict, optional): The payload containing the user ID. Required for unfollowing.
+        db (Session, optional): The database session.
     Returns:
-        dict: A dictionary containing a success message.
-
-    Raises:
-        HTTPException: If the follow relationship does not exist or if there is an internal server error.
+        dict: An object with a message indicating the unfollow was successful.
     """
+    user_id = payload.get("user_id")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="User ID not found."
+        )
+
     follow_relationship = (
         db.query(Follow)
-        .filter(Follow.followerId == followerId, Follow.followedId == followedId)
+        .filter(Follow.followerId == user_id, Follow.followedId == followedId)
         .first()
     )
 


### PR DESCRIPTION
Added route protection to follow and unfollow routes. You can test them by logging in with the login endpoint and then taking the returned jwt and using that as your bearer token in the authorization param.